### PR TITLE
Toggle for ClusterRole and ClusterRoleBinding

### DIFF
--- a/charts/vantage-kubernetes-agent/templates/clusterrole.yaml
+++ b/charts/vantage-kubernetes-agent/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterRole.create  }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -44,4 +45,5 @@ rules:
   resources:
   - "rollouts"
   verbs: ["get", "watch", "list"]
+{{- end}}
 {{- end}}

--- a/charts/vantage-kubernetes-agent/templates/clusterrolebinding.yaml
+++ b/charts/vantage-kubernetes-agent/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterRoleBinding.create  }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,3 +17,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vantage-kubernetes-agent.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end}}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -82,6 +82,9 @@
             "properties": {
                 "annotations": {
                     "type": "object"
+                },
+                "create": {
+                  "type": "boolean"
                 }
             }
         },
@@ -90,6 +93,9 @@
             "properties": {
                 "annotations": {
                     "type": "object"
+                },
+                "create": {
+                  "type": "boolean"
                 }
             }
         },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -106,8 +106,10 @@ serviceAccount:
   name: ""
 
 clusterRole:
+  create: true
   annotations: {}
 clusterRoleBinding:
+  create: true
   annotations: {}
 
 appLabels: {}


### PR DESCRIPTION
## WHAT

Add toggles for the creation of ClusterRole and ClusterRoleBinding resources

## WHY

Currently, these resources can't be conditionally disabled. In our case, we require these to be created in a different context. So adding these toggles will allow us to skip creating them as part of the helm install.

(also submitted upstream: https://github.com/vantage-sh/helm-charts/pull/39 )