### PR TITLE
Add toggle for Service Account creation

### DIFF
--- a/charts/vantage-kubernetes-agent/templates/serviceaccount.yaml
+++ b/charts/vantage-kubernetes-agent/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create  }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,3 +10,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -209,6 +209,9 @@
         "serviceAccount": {
             "type": "object",
             "properties": {
+                "create": {
+                    "type": "boolean"
+                },
                 "annotations": {
                     "type": "object"
                 },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -100,6 +100,7 @@ fullnameOverride: ""
 
 
 serviceAccount:
+  create: true
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template


### PR DESCRIPTION
## WHAT

Adds a toggle for creation of the service account.

## WHY

In our case, we create and manage the service account elsewhere. By making this configurable, we can ensure there's no conflict with the existing SA.