### PR TITLE
Set sync wave for service account

### DIFF
--- a/charts/vantage-kubernetes-agent/templates/serviceaccount.yaml
+++ b/charts/vantage-kubernetes-agent/templates/serviceaccount.yaml
@@ -6,8 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Force Service Account to be created before other resources in ArgoCD, to avoid the issue of the Vantage pod starting, but not having the `AWS_REGION` set.