### PR TITLE
Set persist to null by default

### DIFF
--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -85,11 +85,11 @@ dnsConfig: {}
 #    - name: attempts
 #      value: "3"
 
-persist:
-  mountPath: "/var/lib/vantage-agent"
-  name: "data"
-  size: "10Gi"
-  storageClassName: "" # Optional, uses default if not set
+persist: null
+#  mountPath: "/var/lib/vantage-agent"
+#  name: "data"
+#  size: "10Gi"
+#  storageClassName: "" # Optional, uses default if not set
 
 # Configuration for persisting to S3. The agent will use IAM Roles for Service Accounts to authenticate. This should be setup prior to deploying the agent. See the agent docs for what policy is necessary, https://docs.vantage.sh/kubernetes_agent
 persistS3:


### PR DESCRIPTION
## WHAT

Sets `persist: null` by default.

## WHY

Helm prior to 4.0 has issues with overriding values with multiple values files and `null`. If I set `persist: null` in a later values file, it ignores that value and falls back on this default one instead. That means there is no way for me to set an explicit `persist: null` in cases where I only want `persistS3`.

This chart also has schema validation, so I can't just use something like `persist: false` to force the desired behavior without also skipping schema validation anywhere the chart is used.